### PR TITLE
Guard form_blocks yields and cover label terminators

### DIFF
--- a/Assignment1_CFG/cfg.py
+++ b/Assignment1_CFG/cfg.py
@@ -25,13 +25,16 @@ def form_blocks(body):
 
             #check terminator
             if instr['op'] in TERMINATORS:
-                yield cur_block
+                if cur_block:
+                    yield cur_block
                 cur_block = []
         else: # A label
-            yield cur_block
+            if cur_block:
+                yield cur_block
 
             cur_block = [instr]
-    yield cur_block
+    if cur_block:
+        yield cur_block
 
 def block_map(blocks):
     out = {}

--- a/Assignment1_CFG/test_cfg.py
+++ b/Assignment1_CFG/test_cfg.py
@@ -42,6 +42,21 @@ class TestCFG(unittest.TestCase):
         cfg = generate_cfg(bril_program)
         self.assertEqual(cfg, {"entry": ["exit"], "exit": []})
 
+    def test_label_then_ret(self):
+        bril_program = {
+            "functions": [
+                {
+                    "name": "main",
+                    "instrs": [
+                        {"label": "entry"},
+                        {"op": "ret"}
+                    ]
+                }
+            ]
+        }
+        cfg = generate_cfg(bril_program)
+        self.assertEqual(cfg, {"entry": []})
+
     def test_branch(self):
         bril_program = {
             "functions": [


### PR DESCRIPTION
## Summary
- guard `form_blocks` yields so empty basic blocks are not emitted while keeping existing labels intact
- add a regression test that covers functions beginning with a label and immediate terminator
- ensure the CFG module ends with a trailing newline

## Testing
- python -m unittest
